### PR TITLE
Using filled out URL when metadata scraper fails

### DIFF
--- a/CfpExchange/Views/Cfp/Submit.cshtml
+++ b/CfpExchange/Views/Cfp/Submit.cshtml
@@ -165,7 +165,7 @@
                     $('#eventUrlPreview').show();
                 },
                 error: function() {
-                    // TODO show manual entry
+                    cfpToSubmit.eventUrl = url;
                 }
             });
         }


### PR DESCRIPTION
Fixing (short term) the #19 issue by setting the URL to what the user entered.

Let's assume this URL is correct as it's the one they entered.
Might want to do some sanity checking and blacklisting later on?