### PR TITLE
Features/key vault

### DIFF
--- a/Deployment/CFPExchange.json
+++ b/Deployment/CFPExchange.json
@@ -82,6 +82,12 @@
     },
     "websiteName": {
       "type": "string"
+    },
+    "tenantId": {
+      "type": "string"
+    },
+    "objectId": {
+      "type": "string"
     }
   },
   "resources": [
@@ -396,6 +402,35 @@
       },
       "properties": {
         "ApplicationId": "[parameters('webSiteName')]"
+      }
+    },
+    {
+      "name": "cfpexchange-vault",
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2016-10-01",
+      "location": "West Europe",
+      "tags": {},
+      "properties": {
+        "tenantId": "[parameters('tenantId')]",
+        "sku": {
+          "family": "A",
+          "name": "standard"
+        },
+        "accessPolicies": [
+          {
+            "tenantId": "[parameters('tenantId')]",
+            "objectId": "[parameters('objectId')]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "get"
+              ],
+              "certificates": [],
+              "storage": []
+            }
+          }
+        ],
+        "enabledForTemplateDeployment": true
       }
     }
   ]

--- a/Deployment/CFPExchange.json
+++ b/Deployment/CFPExchange.json
@@ -83,10 +83,10 @@
     "websiteName": {
       "type": "string"
     },
-    "tenantId": {
+    "AD.TenantId": {
       "type": "string"
     },
-    "objectId": {
+    "AD.ObjectId": {
       "type": "string"
     }
   },
@@ -411,15 +411,15 @@
       "location": "West Europe",
       "tags": {},
       "properties": {
-        "tenantId": "[parameters('tenantId')]",
+        "tenantId": "[parameters('AD.TenantId')]",
         "sku": {
           "family": "A",
           "name": "standard"
         },
         "accessPolicies": [
           {
-            "tenantId": "[parameters('tenantId')]",
-            "objectId": "[parameters('objectId')]",
+            "tenantId": "[parameters('AD.TenantId')]",
+            "objectId": "[parameters('AD.ObjectId')]",
             "permissions": {
               "keys": [],
               "secrets": [

--- a/Deployment/CFPExchange.prod.json
+++ b/Deployment/CFPExchange.prod.json
@@ -19,6 +19,12 @@
     },
     "websiteName": {
       "value": "cfpexchange"
+    },
+    "AD.TenantId": {
+      "value": "YourTenantId"
+    },
+    "AD.ObjectId": {
+      "value": "YourAADObjectID"
     }
   }
 }

--- a/Deployment/CFPExchange.test.json
+++ b/Deployment/CFPExchange.test.json
@@ -20,10 +20,10 @@
     "websiteName": {
       "value": "cfpexchange-test"
     },
-    "tenantId": {
+    "AD.TenantId": {
       "value": "YourTenantId"
     },
-    "objectId": {
+    "AD.ObjectId": {
       "value": "YourAADObjectID"
     }
   }

--- a/Deployment/CFPExchange.test.json
+++ b/Deployment/CFPExchange.test.json
@@ -19,6 +19,12 @@
     },
     "websiteName": {
       "value": "cfpexchange-test"
+    },
+    "tenantId": {
+      "value": "YourTenantId"
+    },
+    "objectId": {
+      "value": "YourAADObjectID"
     }
   }
 }


### PR DESCRIPTION
Adds an Azure Key Vault to the resource group.

In order to make this work, you'll need to do some stuff yourself to get everything working in production.

First of all, find your `TentantId` of the Azure subscription.
You should be able to find this in the Azure Portal on the AAD blade. It's the GUID which is called Subscription Id or something similar. By pressing the `Switch directory` link you'll be able to see all subscription id's which you have access too. Choose the one which hosts the CFP Exchange resources.

Second, you need to find the `ObjectId` you want to access the Key Vault.
This one is a bit more tricky as it can be different things. You can configure a User, User Group or Application for this. I chose to use my `App registration` for this (can also be found in the AAD).
Click on the setting `App registration`, press the `View all applications` button and search for the application which matches the CFP Exchange application (mine is called something like `janv-CFP Exchange-[guid]`). Select it and in the overview blade you should see a setting called `Object Id`. That's the one you want to configure!

Copy-paste both the TenantId and the ObjectId, place them in your CD pipeline to the corresponding settings (`AD.TenantId` and `AD.ObjectId`) and your ready to go!


When accessing the Key Vault yourself, you'll probably notice you don't have access. That's normal, as you haven't configured yourself to have access in the ARM template. If you want/need to add secrets (like you probably want to do), you have to grant yourself access in the `Access policies` page.
Don't worry, you can do this without any risk. Whenever a new deployment happens, the access policies are reset. That way you know for sure only the configured application will have access to the Key Vault.


Sounds difficult, but I'm sure you're able to manage. A blogpost containing some more details and pictures will follow soonish on my blog.