### PR TITLE
Features/add servicebus

### DIFF
--- a/Deployment/CFPExchange.json
+++ b/Deployment/CFPExchange.json
@@ -88,7 +88,13 @@
     },
     "AD.ObjectId": {
       "type": "string"
-    }
+    },
+    "servicebusNamespace": {
+      "type": "string"
+    },
+    "serviceBusQueueName": {
+      "type": "string" 
+    } 
   },
   "resources": [
     {
@@ -432,6 +438,30 @@
         ],
         "enabledForTemplateDeployment": true
       }
+    },
+    {
+      "name": "[parameters('servicebusNamespace')]",
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2017-04-01",
+      "location": "West Europe",
+      "kind": "Messaging",
+      "sku": {
+        "name": "Basic"
+      },
+      "properties": {},
+      "resources": [
+        {
+          "apiVersion": "2017-04-01",
+          "name": "[parameters('serviceBusQueueName')]",
+          "type": "Queues",
+          "dependsOn": [
+            "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespace'))]"
+          ],
+          "properties": {
+            "path": "[parameters('serviceBusQueueName')]"
+          }
+        }
+      ]
     }
   ]
 }

--- a/Deployment/CFPExchange.prod.json
+++ b/Deployment/CFPExchange.prod.json
@@ -25,6 +25,12 @@
     },
     "AD.ObjectId": {
       "value": "YourAADObjectID"
+    },
+    "servicebusNamespace": {
+      "value": "cfpexchange-bus"
+    },
+    "serviceBusQueueName": {
+      "value": "eventimages"
     }
   }
 }

--- a/Deployment/CFPExchange.test.json
+++ b/Deployment/CFPExchange.test.json
@@ -25,6 +25,12 @@
     },
     "AD.ObjectId": {
       "value": "YourAADObjectID"
-    }
+    },
+    "servicebusNamespace": {
+      "value": "cfpexchange-bus-test"
+    },
+    "serviceBusQueueName": {
+      "value": "eventimages-test"
+    } 
   }
 }


### PR DESCRIPTION
Also adds an Azure Service Bus with a Queue to the CFP Exchange resource group.
Necessary to implement the proposed functionality of #10.

Nothing fancy here. All the Key Vault stuff has already been mentioned in my earlier PR.
Proposed settings in the `prod` and `test` files might need some changes. I believe the SB Namespaces should be globally unique and I've already used the (test) namespace while testing the template. Haven't used the Production setting though :-)