### PR TITLE
Fixed incorrect URL for RSS feed entries

### DIFF
--- a/CfpExchange/Helpers/Constants.cs
+++ b/CfpExchange/Helpers/Constants.cs
@@ -3,6 +3,6 @@
 	public static class Constants
 	{
 		public const string NoEventImageUrl = "/images/noimage.svg";
-		public const string WebsiteRootUrl = "https://cfp.exchange/";
+		public const string WebsiteRootUrl = "https://cfp.exchange";
 	}
 }

--- a/CfpExchange/Middleware/RssMiddleware.cs
+++ b/CfpExchange/Middleware/RssMiddleware.cs
@@ -47,8 +47,8 @@ namespace CfpExchange.Middleware
 					rssContent += "<item>";
 					rssContent += $"<title>{cfp.EventName}, CFP closes: {cfp.CfpEndDate.ToString("dd MMM yyyy")}</title>";
 					rssContent += $"<pubDate>{cfp.CfpAdded.ToString("r")}</pubDate>";
-					rssContent += $"<link>{_rootUrl}/cfp/{cfp.Slug}</link>";
-					rssContent += $"<guid>{_rootUrl}/cfp/{cfp.Slug}</guid>";
+					rssContent += $"<link>{_rootUrl}/cfp/details/{cfp.Slug}</link>";
+					rssContent += $"<guid>{_rootUrl}/cfp/details/{cfp.Slug}</guid>";
 					rssContent += $"<description>{cfp.EventDescription}</description>";
 					rssContent += "</item>";
 				}

--- a/CfpExchange/Middleware/SitemapMiddleware.cs
+++ b/CfpExchange/Middleware/SitemapMiddleware.cs
@@ -12,81 +12,81 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace CfpExchange.Middleware
 {
-    public class SitemapMiddleware
-    {
-        private readonly RequestDelegate _next;
-        private readonly string _rootUrl;
-        private readonly CfpContext _cfpContext;
+	public class SitemapMiddleware
+	{
+		private readonly RequestDelegate _next;
+		private readonly string _rootUrl;
+		private readonly CfpContext _cfpContext;
 
-        public SitemapMiddleware(RequestDelegate next, string rootUrl, CfpContext cfpContext)
-        {
-            _next = next;
-            _rootUrl = rootUrl;
-            _cfpContext = cfpContext;
-        }
+		public SitemapMiddleware(RequestDelegate next, string rootUrl, CfpContext cfpContext)
+		{
+			_next = next;
+			_rootUrl = rootUrl;
+			_cfpContext = cfpContext;
+		}
 
-        public async Task Invoke(HttpContext context)
-        {
-            if (context.Request.Path.Value.Equals("/sitemap.xml", StringComparison.OrdinalIgnoreCase))
-            {
-                var stream = context.Response.Body;
-                context.Response.StatusCode = 200;
-                context.Response.ContentType = "application/xml";
+		public async Task Invoke(HttpContext context)
+		{
+			if (context.Request.Path.Value.Equals("/sitemap.xml", StringComparison.OrdinalIgnoreCase))
+			{
+				var stream = context.Response.Body;
+				context.Response.StatusCode = 200;
+				context.Response.ContentType = "application/xml";
 
-                string sitemapContent = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">";
+				string sitemapContent = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">";
 
-                var controllers = Assembly.GetExecutingAssembly().GetTypes()
-                    .Where(type => typeof(Controller).IsAssignableFrom(type)
-                        || type.Name.EndsWith("controller", StringComparison.Ordinal)).ToList();
+				var controllers = Assembly.GetExecutingAssembly().GetTypes()
+					.Where(type => typeof(Controller).IsAssignableFrom(type)
+						|| type.Name.EndsWith("controller", StringComparison.Ordinal)).ToList();
 
-                foreach (var controller in controllers)
-                {
-                    var methods = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                    .Where(method => typeof(IActionResult).IsAssignableFrom(method.ReturnType));
+				foreach (var controller in controllers)
+				{
+					var methods = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.Where(method => typeof(IActionResult).IsAssignableFrom(method.ReturnType));
 
-                    foreach (var method in methods)
-                    {
-                        sitemapContent += "<url>";
-                        sitemapContent += $"<loc>{_rootUrl}/{controller.Name.ToLower().Replace("controller", "")}/{method.Name.ToLower()}</loc>";
-                        sitemapContent += string.Format("<lastmod>{0}</lastmod>", DateTime.UtcNow.ToString("yyyy-MM-dd"));
-                        sitemapContent += "</url>";
-                    }
-                }
+					foreach (var method in methods)
+					{
+						sitemapContent += "<url>";
+						sitemapContent += $"<loc>{_rootUrl}/{controller.Name.ToLower().Replace("controller", "")}/{method.Name.ToLower()}</loc>";
+						sitemapContent += string.Format("<lastmod>{0}</lastmod>", DateTime.UtcNow.ToString("yyyy-MM-dd"));
+						sitemapContent += "</url>";
+					}
+				}
 
-                foreach (var cfp in _cfpContext.Cfps.Where(cfp => cfp.CfpEndDate > DateTime.UtcNow))
-                {
-                    sitemapContent += "<url>";
-                    sitemapContent += $"<loc>{_rootUrl}/cfp/details/{cfp.Slug}</loc>";
-                    sitemapContent += $"<lastmod>{cfp.CfpAdded.ToString("yyyy-MM-dd")}</lastmod>";
-                    sitemapContent += "</url>";
-                }
+				foreach (var cfp in _cfpContext.Cfps.Where(cfp => cfp.CfpEndDate > DateTime.UtcNow))
+				{
+					sitemapContent += "<url>";
+					sitemapContent += $"<loc>{_rootUrl}/cfp/details/{cfp.Slug}</loc>";
+					sitemapContent += $"<lastmod>{cfp.CfpAdded.ToString("yyyy-MM-dd")}</lastmod>";
+					sitemapContent += "</url>";
+				}
 
-                sitemapContent += "</urlset>";
+				sitemapContent += "</urlset>";
 
-                using (var memoryStream = new MemoryStream())
-                {
-                    var bytes = Encoding.UTF8.GetBytes(sitemapContent);
-                    memoryStream.Write(bytes, 0, bytes.Length);
-                    memoryStream.Seek(0, SeekOrigin.Begin);
-                    await memoryStream.CopyToAsync(stream, bytes.Length);
-                }
-            }
-            else
-            {
-                await _next(context);
-            }
-        }
-    }
+				using (var memoryStream = new MemoryStream())
+				{
+					var bytes = Encoding.UTF8.GetBytes(sitemapContent);
+					memoryStream.Write(bytes, 0, bytes.Length);
+					memoryStream.Seek(0, SeekOrigin.Begin);
+					await memoryStream.CopyToAsync(stream, bytes.Length);
+				}
+			}
+			else
+			{
+				await _next(context);
+			}
+		}
+	}
 
-    public static partial class BuilderExtensions
-    {
-        public static IApplicationBuilder UseRssMiddleware(this IApplicationBuilder app,
-            string rootUrl = "http://localhost:55556")
-        {
-            var serviceScope = app.ApplicationServices
-                .GetRequiredService<IServiceScopeFactory>().CreateScope();
+	public static partial class BuilderExtensions
+	{
+		public static IApplicationBuilder UseRssMiddleware(this IApplicationBuilder app,
+			string rootUrl = "http://localhost:5000")
+		{
+			var serviceScope = app.ApplicationServices
+				.GetRequiredService<IServiceScopeFactory>().CreateScope();
 
-            return app.UseMiddleware<RssMiddleware>(rootUrl, serviceScope.ServiceProvider.GetService<CfpContext>());
-        }
-    }
+			return app.UseMiddleware<RssMiddleware>(rootUrl, serviceScope.ServiceProvider.GetService<CfpContext>());
+		}
+	}
 }

--- a/CfpExchange/Middleware/SitemapMiddleware.cs
+++ b/CfpExchange/Middleware/SitemapMiddleware.cs
@@ -12,82 +12,81 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace CfpExchange.Middleware
 {
-	public class SitemapMiddleware
-	{
-		private readonly RequestDelegate _next;
-		private readonly string _rootUrl;
-		private readonly CfpContext _cfpContext;
+    public class SitemapMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly string _rootUrl;
+        private readonly CfpContext _cfpContext;
 
-		public SitemapMiddleware(RequestDelegate next, string rootUrl, CfpContext cfpContext)
-		{
-			_next = next;
-			_rootUrl = rootUrl;
-			_cfpContext = cfpContext;
-		}
+        public SitemapMiddleware(RequestDelegate next, string rootUrl, CfpContext cfpContext)
+        {
+            _next = next;
+            _rootUrl = rootUrl;
+            _cfpContext = cfpContext;
+        }
 
-		public async Task Invoke(HttpContext context)
-		{
-			if (context.Request.Path.Value.Equals("/sitemap.xml", StringComparison.OrdinalIgnoreCase))
-			{
-				var stream = context.Response.Body;
-				context.Response.StatusCode = 200;
-				context.Response.ContentType = "application/xml";
+        public async Task Invoke(HttpContext context)
+        {
+            if (context.Request.Path.Value.Equals("/sitemap.xml", StringComparison.OrdinalIgnoreCase))
+            {
+                var stream = context.Response.Body;
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "application/xml";
 
-				string sitemapContent = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">";
+                string sitemapContent = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">";
 
-				var controllers = Assembly.GetExecutingAssembly().GetTypes()
-					.Where(type => typeof(Controller).IsAssignableFrom(type)
-						|| type.Name.EndsWith("controller", StringComparison.Ordinal)).ToList();
+                var controllers = Assembly.GetExecutingAssembly().GetTypes()
+                    .Where(type => typeof(Controller).IsAssignableFrom(type)
+                        || type.Name.EndsWith("controller", StringComparison.Ordinal)).ToList();
 
-				foreach (var controller in controllers)
-				{
-					var methods = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-					.Where(method => typeof(IActionResult).IsAssignableFrom(method.ReturnType));
-					
-					foreach (var method in methods)
-					{
-						sitemapContent += "<url>";
-						sitemapContent += $"<loc>{_rootUrl}/{controller.Name.ToLower().Replace("controller", "")}/{method.Name.ToLower()}</loc>";
-						sitemapContent += string.Format("<lastmod>{0}</lastmod>", DateTime.UtcNow.ToString("yyyy-MM-dd"));
-						sitemapContent += "</url>";
-					}
-				}
+                foreach (var controller in controllers)
+                {
+                    var methods = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    .Where(method => typeof(IActionResult).IsAssignableFrom(method.ReturnType));
 
-				foreach (var cfp in _cfpContext.Cfps.Where(cfp => cfp.CfpEndDate > DateTime.UtcNow))
-				{
-					sitemapContent += "<url>";
-					sitemapContent += $"<loc>{_rootUrl}/cfp/details/{cfp.Slug}</loc>";
-					sitemapContent += $"<lastmod>{cfp.CfpAdded.ToString("yyyy-MM-dd")}</lastmod>";
-					sitemapContent += "</url>";
-				}
+                    foreach (var method in methods)
+                    {
+                        sitemapContent += "<url>";
+                        sitemapContent += $"<loc>{_rootUrl}/{controller.Name.ToLower().Replace("controller", "")}/{method.Name.ToLower()}</loc>";
+                        sitemapContent += string.Format("<lastmod>{0}</lastmod>", DateTime.UtcNow.ToString("yyyy-MM-dd"));
+                        sitemapContent += "</url>";
+                    }
+                }
 
-				sitemapContent += "</urlset>";
+                foreach (var cfp in _cfpContext.Cfps.Where(cfp => cfp.CfpEndDate > DateTime.UtcNow))
+                {
+                    sitemapContent += "<url>";
+                    sitemapContent += $"<loc>{_rootUrl}/cfp/details/{cfp.Slug}</loc>";
+                    sitemapContent += $"<lastmod>{cfp.CfpAdded.ToString("yyyy-MM-dd")}</lastmod>";
+                    sitemapContent += "</url>";
+                }
 
-				using (var memoryStream = new MemoryStream())
-				{
-					var bytes = Encoding.UTF8.GetBytes(sitemapContent);
-					memoryStream.Write(bytes, 0, bytes.Length);
-					memoryStream.Seek(0, SeekOrigin.Begin);
-					await memoryStream.CopyToAsync(stream, bytes.Length);
-				}
-			}
-			else
-			{
-				await _next(context);
-			}
-		}
-	}
+                sitemapContent += "</urlset>";
 
-	public static partial class BuilderExtensions
-	{
-		public static IApplicationBuilder UseRssMiddleware(this IApplicationBuilder app,
-			string rootUrl = "http://localhost:5000")
-		{
-			var serviceScope = app.ApplicationServices
-				.GetRequiredService<IServiceScopeFactory>().CreateScope();
-			
-				return app.UseMiddleware<RssMiddleware>(rootUrl, serviceScope.ServiceProvider.GetService<CfpContext>());
-			
-		}
-	}
+                using (var memoryStream = new MemoryStream())
+                {
+                    var bytes = Encoding.UTF8.GetBytes(sitemapContent);
+                    memoryStream.Write(bytes, 0, bytes.Length);
+                    memoryStream.Seek(0, SeekOrigin.Begin);
+                    await memoryStream.CopyToAsync(stream, bytes.Length);
+                }
+            }
+            else
+            {
+                await _next(context);
+            }
+        }
+    }
+
+    public static partial class BuilderExtensions
+    {
+        public static IApplicationBuilder UseRssMiddleware(this IApplicationBuilder app,
+            string rootUrl = "http://localhost:55556")
+        {
+            var serviceScope = app.ApplicationServices
+                .GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+            return app.UseMiddleware<RssMiddleware>(rootUrl, serviceScope.ServiceProvider.GetService<CfpContext>());
+        }
+    }
 }

--- a/CfpExchange/appsettings.Development.json
+++ b/CfpExchange/appsettings.Development.json
@@ -12,5 +12,5 @@
     "ApiBaseUri": "https://api.mailgun.net/v3/",
     "RequestUri": "cfpexchange.mailgun.org/messages",
     "From": "development@cfpexchange.mailgun.org"
-  }
+  } 
 }


### PR DESCRIPTION
The URL for RSS Feeds is currently incorrect. Links have the following form:

_https://cfp.exchange//cfp/net-conf-cl-v2018_

Notice the double forward slash and the missing _details_ part in the URL. This pull request removes the forward slash from `Constants.cs `and adds a` details `URL segment.