### PR TITLE
Fixed an old migration

### DIFF
--- a/CfpExchange/Migrations/20180609180239_AddedExpensesToCfpAndUserStuff.cs
+++ b/CfpExchange/Migrations/20180609180239_AddedExpensesToCfpAndUserStuff.cs
@@ -193,6 +193,12 @@ namespace CfpExchange.Migrations
                 column: "NormalizedUserName",
                 unique: true,
                 filter: "[NormalizedUserName] IS NOT NULL");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProvidedExpenses",
+                table: "Cfps",
+                nullable: false,
+                defaultValue: 0);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -217,6 +223,11 @@ namespace CfpExchange.Migrations
 
             migrationBuilder.DropTable(
                 name: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "ProvidedExpenses",
+                table: "Cfps");
+
         }
     }
 }


### PR DESCRIPTION
Added the missing column to the migration, because it's being dropped in the next migration. Mentioned in #60  

I'm aware of the risk in changing old migrations, but this appears to be a pretty safe change.