### PR TITLE
Styles location link

### DIFF
--- a/Themes/CFPThemeV1/less/styles.less
+++ b/Themes/CFPThemeV1/less/styles.less
@@ -552,6 +552,15 @@ body {
         font-size: .95rem;
       }
     }
+
+    a {
+      color: #ffff;
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
   }
 
   .ingredient-direction {


### PR DESCRIPTION
The location link showing on the CFP detail page was blue which doesn't look to good on a red background. Made it white.